### PR TITLE
ci: add GitHub Actions workflows and Renovate for dependency management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,104 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
+      - name: Run golangci-lint (protoc plugin)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: protoc-gen-k6-connectrpc
+
+  test:
+    name: Test (Go ${{ matrix.go-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ['1.23', '1.24']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Verify dependencies
+        run: |
+          go mod verify
+          go mod download
+
+      - name: Run tests
+        run: go test -v -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        if: matrix.go-version == '1.24'
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  build-extension:
+    name: Build k6 Extension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install xk6
+        run: go install go.k6.io/xk6/cmd/xk6@latest
+
+      - name: Build k6 with extension
+        run: xk6 build --with github.com/bumberboy/xk6-connectrpc=.
+
+      - name: Verify binary
+        run: ./k6 version
+
+  build-protoc-plugin:
+    name: Build Protoc Plugin
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: protoc-gen-k6-connectrpc
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'protoc-gen-k6-connectrpc/go.mod'
+
+      - name: Verify dependencies
+        run: go mod verify
+
+      - name: Build plugin
+        run: go build -o protoc-gen-k6-connectrpc .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,149 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., v1.0.0)'
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install xk6
+        run: go install go.k6.io/xk6/cmd/xk6@latest
+
+      - name: Determine extension
+        id: ext
+        run: |
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            echo "ext=.exe" >> $GITHUB_OUTPUT
+          else
+            echo "ext=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build k6 binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          xk6 build --with github.com/bumberboy/xk6-connectrpc=. \
+            --output k6-connectrpc-${{ matrix.goos }}-${{ matrix.goarch }}${{ steps.ext.outputs.ext }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-connectrpc-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: k6-connectrpc-*
+          retention-days: 1
+
+  build-protoc-plugin:
+    name: Build Protoc Plugin (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+    defaults:
+      run:
+        working-directory: protoc-gen-k6-connectrpc
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'protoc-gen-k6-connectrpc/go.mod'
+
+      - name: Determine extension
+        id: ext
+        run: |
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            echo "ext=.exe" >> $GITHUB_OUTPUT
+          else
+            echo "ext=" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build protoc plugin
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -o protoc-gen-k6-connectrpc-${{ matrix.goos }}-${{ matrix.goarch }}${{ steps.ext.outputs.ext }} .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: protoc-gen-k6-connectrpc-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: protoc-gen-k6-connectrpc/protoc-gen-k6-connectrpc-*
+          retention-days: 1
+
+  release:
+    name: Create Release
+    needs: [build, build-protoc-plugin]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List artifacts
+        run: ls -la dist/
+
+      - name: Create checksums
+        working-directory: dist
+        run: |
+          sha256sum * > checksums.txt
+          cat checksums.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*
+          generate_release_notes: true
+          draft: false
+          fail_on_unmatched_files: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":gomod",
+    ":semanticCommits"
+  ],
+  "schedule": ["before 9am on monday"],
+  "timezone": "UTC",
+  "labels": ["dependencies"],
+  "golang": {
+    "enabled": true
+  },
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "description": "Group Go version updates",
+      "matchManagers": ["gomod"],
+      "matchDepTypes": ["golang"],
+      "groupName": "Go version",
+      "automerge": false
+    },
+    {
+      "description": "Group k6 ecosystem updates",
+      "matchPackagePatterns": ["^go\\.k6\\.io/"],
+      "groupName": "k6 ecosystem"
+    },
+    {
+      "description": "Group gRPC and Connect ecosystem updates",
+      "matchPackagePatterns": [
+        "^google\\.golang\\.org/grpc",
+        "^google\\.golang\\.org/protobuf",
+        "^connectrpc\\.com/"
+      ],
+      "groupName": "gRPC/Connect ecosystem"
+    },
+    {
+      "description": "Group OpenTelemetry updates",
+      "matchPackagePatterns": ["^go\\.opentelemetry\\.io/"],
+      "groupName": "OpenTelemetry"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Auto-merge patch updates for test dependencies",
+      "matchPackagePatterns": ["^github\\.com/stretchr/testify"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "description": "Auto-merge minor and patch updates for GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ],
+  "ignorePaths": ["**/testdata/**"]
+}


### PR DESCRIPTION
- Add CI workflow with linting (golangci-lint), testing (Go 1.23/1.24),
  and build verification for both the k6 extension and protoc plugin
- Add release workflow for multi-platform binary builds (linux, darwin, windows)
- Add Renovate configuration for automated dependency updates including
  Go version updates, with grouped PRs for k6, gRPC/Connect, and OpenTelemetry